### PR TITLE
Requirements.txt: Incorporate module renames of (py-)lief and (py)torch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ capstone
 dgl
 numpy
 pandas
-py-lief
+lief
 pytest
-pytorch
+torch
 pygraphviz
 pyaml
 typing-extensions


### PR DESCRIPTION
pip install no longer finds py-lief and complains about pytorch. Looks like they have been renamed to lief and torch, respectively.